### PR TITLE
Fix Comments and jsdoc configuration file to run jsdoc

### DIFF
--- a/jsdoc.conf
+++ b/jsdoc.conf
@@ -1,4 +1,5 @@
 {
+    "sourceType": "src/Layer/MocLayer.js",
     "tags": {
         "allowUnknownTags": true,
         "dictionaries": ["jsdoc","closure"]

--- a/src/Layer/OpenSearchLayer.js
+++ b/src/Layer/OpenSearchLayer.js
@@ -707,11 +707,10 @@ define(['jquery','../Renderer/FeatureStyle', '../Renderer/VectorRendererManager'
         /**************************************************************************************************************/
 
         /**
-         * Prepare paramters for a given bound
+         * Prepare parameters for a given bound
          * @function prepareParameters
          * @memberof OpenSearchLayer#
          * @param {Bound} bound Bound
-         * @return 
          */
         OpenSearchLayer.prototype.prepareParameters = function (bound) {
             var param;      // param managed


### PR DESCRIPTION
Hello,

Two small fixes (one on comment and another one on the jsdoc configuration file) to be able to run jsdoc through "npm run jsdoc"