### PR TITLE
Setup various headers when contacting OpenSearch backends

### DIFF
--- a/src/Layer/AbstractLayer.js
+++ b/src/Layer/AbstractLayer.js
@@ -550,6 +550,9 @@ define(["jquery", "underscore-min", "../Utils/Event", "moment", "../Time/Time", 
                 url: url,
                 dataType: 'text',
                 async: false,
+                beforeSend(xhr) {
+                    xhr.setRequestHeader("Accept", "application/xml");
+                },
                 success: function (response) {
                     var myOptions = {
                         mergeCDATA: true,

--- a/src/Layer/OpenSearch/OpenSearchRequestPool.js
+++ b/src/Layer/OpenSearch/OpenSearchRequestPool.js
@@ -169,6 +169,7 @@ function () {
             }
         };
         xhr.open("GET", url);
+        xhr.setRequestHeader("Accept", "application/json");
 
         // Add request to pooling (last position)
         this.poolingRequests.push(xhr);


### PR DESCRIPTION
For REGARDS OSS, we need that Mizar specifies these 2 headers more strictly otherwise our server is a bit lost.